### PR TITLE
Create Base Cache Interface Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 dist/
 *.egg-info/
 docs/_build/
+venv

--- a/atm/cache_interface.py
+++ b/atm/cache_interface.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import requests
+import os
+from hashlib import sha1
+from datetime import datetime
+
+
+class CacheInterface(object):
+  """
+  An base class for declaring the cache interface
+  """
+  def __init__(self, uri, format='txt', interval=None):
+    self.uri = uri
+    self.format = format.lower()
+    self.interval = interval
+
+  def withdraw(self, filepath):
+    """ Retrieves a file from the cache"""
+    pass
+
+  def liquidate(self):
+    """ Retrieve all files from the cache. Returns a generator"""
+    pass
+
+  def default(self):
+    """ Delete all files from the cache"""
+    pass
+
+  def statement(self):
+    """ List all files in the cache """
+    pass
+
+  def transaction(self, url, timestamp = None):
+    """ get the filepath for the contents of a url in the cache"""
+    if timestamp:
+      timestamp = str(self._round_timestamp_to_interval(timestamp))
+
+    return self._url_to_filepath(url, timestamp)
+
+  def _resp_from_request(self, url):
+    response = requests.get(url)
+
+    status_code = response.status_code
+
+    if response.status_code != 200:
+      return status_code, None
+
+    # fetch
+    if self.format == "json":
+      return status_code, response.json()
+
+    elif self.format == "txt":
+      return status_code, response.content
+
+  def _url_to_filepath(self, url, interval_string):
+    """ Make a url into a file name, using SHA1 hashes. """
+
+    # use a sha1 hash to convert the url into a unique filepath
+    hash_file = "%s.%s" % (sha1(url).hexdigest(), self.format)
+    if interval_string:
+      hash_file = "%s-%s" % (interval_string, hash_file)
+
+    return os.path.join(self.cache_dir, hash_file)
+
+  def _gen_interval_string(self):
+    """Generate a timestamp string that will be used to update the cache at a set interval"""
+    now = int(datetime.now().strftime("%s"))
+    if self.interval:
+      return self._round_timestamp_to_interval(now)
+    else:
+      return None
+
+  def _round_timestamp_to_interval(self, ts):
+    """Generate a timestamp string that will be used to update the cache at a set interval"""
+    return int(ts) - int(ts % int(self.interval))

--- a/atm/local.py
+++ b/atm/local.py
@@ -3,6 +3,10 @@
 import os
 import json
 
+from cache_interface import CacheInterface
+from responses import ATM_Response
+
+
 def store_local(local_path, content, format):
   """ Save a local copy of the file. """
   # Save to disk.
@@ -11,7 +15,7 @@ def store_local(local_path, content, format):
     if format == 'json':
       f.write(json.dumps(content))
 
-    elif format=="txt":
+    elif format == "txt":
       return f.write(content)
 
 
@@ -22,7 +26,7 @@ def load_local(local_path, format):
     return None
 
   with open(local_path, 'rb') as f:
-    if format=='json':
+    if format == 'json':
       try:
         content = json.load(f)
       except ValueError:
@@ -30,5 +34,67 @@ def load_local(local_path, format):
       else:
         return content
 
-    elif format=="txt":
+    elif format == "txt":
       return f.read()
+
+
+class LocalCacheInterface(CacheInterface):
+  """
+  An interface for caching files locally
+  """
+
+  @staticmethod
+  def accepts_uri(uri):
+    # This one seems to be the fallback
+    return True
+
+  def __init__(self, *args, **kwargs):
+      super(LocalCacheInterface, self).__init__(*args, **kwargs)
+      self.cache_dir = self.uri
+      # If the cache directory does not exist, make one.
+      if not os.path.isdir(self.cache_dir):
+        os.makedirs(self.cache_dir)
+
+  def get_cache(self, url):
+    """ Wrap requests.get() """
+    # create a filepath
+    interval_string = self._gen_interval_string()
+    filepath = self._url_to_filepath(url, interval_string)
+
+    content = load_local(filepath, self.format)
+    status_code = None
+    # if it doesen't exist, fetch the url and cache it.
+    if content is None:
+      status_code, content = self._resp_from_request(url)
+      store_local(filepath, content, self.format)
+
+    return ATM_Response(
+      content = content,
+      url = url,
+      is_s3= False,
+      filepath = filepath,
+      cache_dir = self.cache_dir,
+      bucket_name = None,
+      status_code = status_code,
+      source = "cache" if status_code is None else "url",
+      timestamp = int(interval_string) if interval_string else None
+    )
+
+  def withdraw(self, filepath):
+    """ Retrieves a file from the cache"""
+    return load_local(filepath, self.format)
+
+  def liquidate(self):
+    """ Retrieve all files from the cache. Returns a generator"""
+    for filepath in self.statement():
+      yield load_local(filepath, self.format)
+
+  def default(self):
+    """ Delete all files from the cache"""
+    for filepath in self.statement():
+      os.remove(filepath)
+
+  def statement(self):
+    """ List all files in the cache """
+    return [os.path.join(self.cache_dir, f) for f in os.listdir(self.cache_dir)]
+

--- a/atm/main.py
+++ b/atm/main.py
@@ -1,172 +1,31 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import requests
-from urlparse import urljoin
-import os, re
-from hashlib import sha1
-import json
-from s3 import is_s3_uri, S3
+from s3 import S3CacheInterface
 
-from local import load_local, store_local
-from datetime import datetime
+from local import LocalCacheInterface
 
+interfaces = (S3CacheInterface, LocalCacheInterface)
 
-class ATM_Response(object):
-  """a return object for ATM.get_cache"""
-  def __init__(self, content,  url, filepath, cache_dir, bucket_name, is_s3, status_code, source, timestamp):
-    self.content = content
-    self.url = url
-    self.filepath = filepath
-    self.cache_dir = cache_dir
-    self.bucket_name =  bucket_name
-    self.is_s3 = is_s3
-    self.status_code = status_code
-    self.source = source
-    self.timestamp = timestamp
 
 class ATM_Error(Exception):
   pass
+
 
 class ATM(object):
   """
   A class for intelligently caching / retrieving data fetched from urls
   """
-  def __init__(self, cache_dir, format="txt", interval = None):
-    
-    # determine s3 / local
-    if is_s3_uri(cache_dir):
-      self.is_s3 = True
-      self.s3 = S3(cache_dir)
-      self.cache_dir = self.s3.cache_dir
-      self.bucket_name = self.s3.bucket_name
+  def __init__(self, *args, **kwargs):
+    # This could be done cleaner if we could change the interface.
+    # Something like ATM.from_s3_url() and such, for for now I will just
+    # leave this as is
+    return None
 
-    else:
-      self.is_s3 = False
-      self.cache_dir = cache_dir
-      self.bucket_name = None
-      
-      # If the cache directory does not exist, make one.
-      if not os.path.isdir(self.cache_dir):
-        os.makedirs(self.cache_dir)
-
-    self.format = format.lower()
-    self.interval = interval
-
-  def get_cache(self, url):
-    """ Wrap requests.get() """
-    # create a filepath
-    interval_string = self._gen_interval_string()
-    filepath = self._url_to_filepath(url, interval_string)
-
-    # get cached content
-    if self.is_s3:
-      content = self.s3.download(filepath, self.format)
-
-    else:
-      content = load_local(filepath, self.format)
-
-    # if it doesen't exist, fetch the url and cache it.
-    if content is None:
-      response = requests.get(url)
-
-      status_code = response.status_code
-      
-      if response.status_code != 200:
-        content = None
-         
+  def __new__(cls, cache_url, *args, **kwargs):
+    print '%s, %s, %s' % (cache_url, args, kwargs)
+    for interface in interfaces:
+      if interface.accepts_uri(cache_url):
+        print 'Found interface'
+        return interface(cache_url, *args, **kwargs)
       else:
-        # fetch
-        if self.format =="json":
-          content = response.json()
-
-        elif self.format =="txt":
-          content = response.content
-
-        # cache
-        if self.is_s3:
-          self.s3.upload(filepath, content, self.format)
-          
-        else:
-          store_local(filepath, content, self.format)
-
-    else:
-
-      status_code = None
-
-    return ATM_Response(
-      content = content,
-      url = url,
-      filepath = filepath,
-      cache_dir = self.cache_dir,
-      bucket_name = self.bucket_name,
-      is_s3 = self.is_s3,
-      status_code = status_code,
-      source = "cache" if status_code is None else "url",
-      timestamp = int(interval_string) if interval_string else None
-    ) 
-
-  def withdraw(self, filepath):
-    """ Retrieves a file from the cache"""
-    if self.is_s3:
-      return self.s3.download(filepath, self.format)
-    else:
-      return load_local(filepath, self.format)
-
-  def liquidate(self):
-    """ Retrieve all files from the cache. Returns a generator"""
-    if self.is_s3:
-      for filepath in self.statement():
-        yield self.s3.download(filepath, self.format)
-    else:
-      for filepath in self.statement():
-        yield load_local(filepath, self.format)
-
-  def default(self):
-    """ Delete all files from the cache"""
-    if self.is_s3:
-      for filepath in self.statement():
-        self.s3.delete(filepath)
-    else:
-      for filepath in self.statement():
-        os.remove(filepath)
-
-  def statement(self):
-    """ List all files in the cache """
-    if self.is_s3:
-        return [k.key for k in self.s3.bucket.list(self.cache_dir)]
-    else:
-      return [os.path.join(self.cache_dir, f) for f in os.listdir(self.cache_dir)]
-
-  def transaction(self, url, timestamp = None):
-    """ get the filepath for the contents of a url in the cache"""
-    if timestamp:
-      timestamp = str(self._round_timestamp_to_interval(timestamp))
-
-    return self._url_to_filepath(url, timestamp)
-
-  def _url_to_filepath(self, url, interval_string):
-    """ Make a url into a file name, using SHA1 hashes. """
-
-    # use a sha1 hash to convert the url into a unique filepath
-    hash_file = "%s.%s" % (sha1(url).hexdigest(), self.format)
-    if interval_string:
-      hash_file = "%s-%s" % (interval_string, hash_file)
-
-    return os.path.join(self.cache_dir, hash_file)
-
-  def _gen_interval_string(self):
-    """Generate a timestamp string that will be used to update the cache at a set interval"""
-    now = int(datetime.now().strftime("%s"))
-    if self.interval:
-      return self._round_timestamp_to_interval(now)
-    else:
-      return None
-
-  def _round_timestamp_to_interval(self, ts):
-    """Generate a timestamp string that will be used to update the cache at a set interval"""
-    return int(ts) - int(ts % int(self.interval))
-
-
-
-
-
+        print 'No one wants it'

--- a/atm/responses.py
+++ b/atm/responses.py
@@ -1,0 +1,14 @@
+
+
+class ATM_Response(object):
+  """a return object for ATM.get_cache"""
+  def __init__(self, content,  url, filepath, cache_dir, bucket_name, is_s3, status_code, source, timestamp):
+    self.content = content
+    self.url = url
+    self.filepath = filepath
+    self.cache_dir = cache_dir
+    self.bucket_name =  bucket_name
+    self.is_s3 = is_s3
+    self.status_code = status_code
+    self.source = source
+    self.timestamp = timestamp

--- a/atm/s3.py
+++ b/atm/s3.py
@@ -4,9 +4,11 @@ import os
 import boto
 import boto.s3
 from boto.s3.key import Key
-import sys
 import json
-from urlparse import urlparse, urljoin
+from urlparse import urlparse
+
+from cache_interface import CacheInterface
+from responses import ATM_Response
 
 def is_s3_uri(uri):
   """Return True if *uri* can be parsed into an S3 URI, False otherwise."""
@@ -26,7 +28,7 @@ def parse_s3_uri(uri):
   """
   if not uri.endswith('/'):
     uri += '/'
-    
+
   components = urlparse(uri)
   if (components.scheme not in ('s3', 's3n')
           or '/' not in components.path):
@@ -43,6 +45,7 @@ class S3(object):
   def _connect_to_bucket(self, bucket_name):
     AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+
     conn = boto.connect_s3(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
     for i in conn.get_all_buckets():
       if bucket_name == i.name:
@@ -71,3 +74,80 @@ class S3(object):
     k = Key(self.bucket)
     k.key = filepath
     self.bucket.delete_key(k)
+
+
+class S3CacheInterface(CacheInterface):
+  """
+  A class for intelligently caching / retrieving data fetched from urls
+  """
+
+  @staticmethod
+  def accepts_uri(uri):
+    if not uri.endswith('/'):
+      uri += '/'
+
+    components = urlparse(uri)
+    if (components.scheme not in ('s3', 's3n')
+            or '/' not in components.path):
+      return False
+
+    return True
+
+  def __init__(self, *args, **kwargs):
+    super(S3CacheInterface, self).__init__(*args, **kwargs)
+    self.is_s3 = True
+    self.s3 = S3(self.uri)
+    self.cache_dir = self.s3.cache_dir
+    self.bucket_name = self.s3.bucket_name
+
+  def get_cache(self, url):
+    """ Wrap requests.get() """
+    # create a filepath
+    interval_string = self._gen_interval_string()
+    filepath = self._url_to_filepath(url, interval_string)
+    content = self.s3.download(filepath, self.format)
+
+    status_code = None
+    # if it doesen't exist, fetch the url and cache it.
+    if content is None:
+      status_code, content = self._resp_from_request(url)
+      self.s3.upload(filepath, content, self.format)
+
+    return ATM_Response(
+      content = content,
+      url = url,
+      filepath = filepath,
+      cache_dir = self.cache_dir,
+      bucket_name = self.bucket_name,
+      is_s3 = self.is_s3,
+      status_code = status_code,
+      source = "cache" if status_code is None else "url",
+      timestamp = int(interval_string) if interval_string else None
+    )
+
+  def withdraw(self, filepath):
+    """ Retrieves a file from the cache"""
+    return self.s3.download(filepath, self.format)
+
+  def liquidate(self):
+    """ Retrieve all files from the cache. Returns a generator"""
+    for filepath in self.statement():
+      yield self.s3.download(filepath, self.format)
+
+  def default(self):
+    """ Delete all files from the cache"""
+    for filepath in self.statement():
+      self.s3.delete(filepath)
+
+
+  def statement(self):
+    """ List all files in the cache """
+    return [k.key for k in self.s3.bucket.list(self.cache_dir)]
+
+
+  def transaction(self, url, timestamp = None):
+    """ get the filepath for the contents of a url in the cache"""
+    if timestamp:
+      timestamp = str(self._round_timestamp_to_interval(timestamp))
+
+    return self._url_to_filepath(url, timestamp)

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Set up a cache on Amazon S3:
 Do this as follows:
 ```
 $ export AWS_ACCESS_KEY_ID="myaccesskeyid"
-$ export AWS_ACCESS_KEY_ID="myaccesskeysecret"
+$ export AWS_SECRET_ACCESS_KEY="myaccesskeysecret"
 ```
 
 Now you're all set to cache results on S3:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 boto
 requests
+redis

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
     zip_safe = False,
     install_requires = [
         "boto",
-        "requests"
+        "requests",
+        "redis",
     ],
     tests_require = []
 )

--- a/tests/atm_tests.py
+++ b/tests/atm_tests.py
@@ -1,19 +1,19 @@
+import os
 import unittest
 from hashlib import sha1
 import time
 import shutil
 import requests
-import time
 
-from atm import ATM 
+from atm import ATM
 from atm.s3 import is_s3_uri, parse_s3_uri
 
 url = 'http://www.google.com'
 url2 = 'http://www.nytimes.com'
 local_cache_dir = 'cache-atm-tests-12345678910'
-s3_cache_dir = 's3://atm-test-bucket/cache/'
+s3_cache_dir = os.getenv('TEST_S3_CACHE_DIR', 's3://atm-test-bucket/cache/')
 s3_file = 'http://atm-test-bucket.s3.amazonaws.com/fixtures/foo.txt'
-s3_bucket = "atm-test-bucket"
+s3_bucket = os.getenv('TEST_S3_BUCKET', "atm-test-bucket")
 s3_path = "cache/"
 
 class ATMTests(unittest.TestCase):
@@ -69,7 +69,7 @@ class ATMTests(unittest.TestCase):
     # remove cache directory
     shutil.rmtree(local_cache_dir)
 
-    assert len(statement) == 2 
+    assert len(statement) == 2
 
   def test_local_default(self):
     teller = ATM(local_cache_dir)
@@ -100,7 +100,7 @@ class ATMTests(unittest.TestCase):
     r = teller.get_cache(url)
 
     statement = teller.statement()
-    
+
     # remove cache directory
     shutil.rmtree(local_cache_dir)
 
@@ -111,7 +111,7 @@ class ATMTests(unittest.TestCase):
     teller = ATM(s3_cache_dir)
     r = teller.get_cache(url)
     r = teller.get_cache(url2)
-    
+
     assets = [f for f in teller.liquidate()]
 
     # remove files
@@ -130,7 +130,7 @@ class ATMTests(unittest.TestCase):
     # remove files
     teller.default()
 
-    assert len(statement) == 2 
+    assert len(statement) == 2
 
   def test_s3_default(self):
     teller = ATM(s3_cache_dir)
@@ -152,7 +152,7 @@ class ATMTests(unittest.TestCase):
 
   def test_s3_interval(self):
     teller = ATM(s3_cache_dir, interval=10)
-    
+
     # remove cache directory
     teller.default()
 
@@ -182,8 +182,4 @@ class ATMTests(unittest.TestCase):
     teller.default()
 
     assert source1=="url" and source2=="cache"
-
-
-
-
 


### PR DESCRIPTION
This is what I was talking about in issue #1

I attempted to create a base cache interface class. I then refactored
the other two current cache implmentations to inherit from this
base class.

Then I was able to use ATM as just an interface broker.

This should make it much easier to implment new cache interfaces, like
redis for instance.
- I made sure the tests pass, and made it easier for others to run
  tests using their own setup.
- Fixed a bug in the readme
